### PR TITLE
single quotes breaking

### DIFF
--- a/systemd-cgroup-gc.yaml
+++ b/systemd-cgroup-gc.yaml
@@ -15,7 +15,7 @@ data:
     count=0
     for i in $(runhost ls /sys/fs/cgroup/systemd/system.slice |grep "^run-r"); do
     pod=$(runhost systemctl list-units --type scope --state running $i |cat |sed -n 's/\(.*\)Kubernetes transient mount for \/var\/lib\/kubelet\/pods\/\(.*\)\/volumes\(.*\)/\2/p')
-    if [ ! -e "/var/lib/kubelet/pods/'$pod'" ]; then
+    if [ ! -e "/var/lib/kubelet/pods/$pod" ]; then
       echo -n "Try to stop '$i' systemd scope... "
       runhost systemctl stop $i
       echo "Stopped."


### PR DESCRIPTION
In testing, I believe the single quotes are breaking the if statement.

With pod written as '$pod' in the script i'm seeing it looking for `/var/lib/kubelet/pods/'871faf1f-e70a-11e9-9096-000d3a027f9e'` which is not correct.
```
Try to stop 'run-r012b0cf94a0e49cd91238e26589b36b6.scope' systemd scope... Stopped.
/var/lib/kubelet/pods/'8392a6bf-e73a-11e9-a159-000d3a02729f' not found!
Try to stop 'run-r012fad6a9e0742cb85ed4c81abf6a27d.scope' systemd scope... Stopped.
/var/lib/kubelet/pods/'' not found!
Try to stop 'run-r01309a7d4482455597a046b51a845735.scope' systemd scope... Stopped.
/var/lib/kubelet/pods/'871faf1f-e70a-11e9-9096-000d3a027f9e' not found!
Try to stop 'run-r0133d0a18e9a4681bfe1f4fcec76bbf1.scope' systemd scope... Stopped.
/var/lib/kubelet/pods/'845e6a55-e703-11e9-9096-000d3a027f9e' not found!
Try to stop 'run-r013b4441c9fc479585edd4b71387c178.scope' systemd scope... Stopped.
```

Updating the script to remove the single quotes around $pod i'm seeing this work better.
```
	count=0
	for i in $(ls /sys/fs/cgroup/systemd/system.slice |grep "^run-r"); do
	pod=$(systemctl list-units --type scope --state running $i |cat |sed -n 's/\(.*\)Kubernetes transient mount for \/var\/lib\/kubelet\/pods\/\(.*\)\/volumes\(.*\)/\2/p')
	if [ ! -e "/var/lib/kubelet/pods/$pod" ]; then
	 echo "/var/lib/kubelet/pods/$pod not found!"
	  echo -n "Try to stop '$i' systemd scope... "
	  #systemctl stop $i
	  echo "Stopped."
	  count=$((count + 1))
	fi
	done
	echo "Total ${count} systemd scope stopped."
```

```
/var/lib/kubelet/pods/22e84a1b-e490-11e9-9096-000d3a027f9e not found!
Try to stop 'run-r14028d7792ea4df49800e9e68fc20c0e.scope' systemd scope... Stopped.
/var/lib/kubelet/pods/b0eb60be-e491-11e9-9096-000d3a027f9e not found!
Try to stop 'run-r14032dab38864c719be66f360254cf3a.scope' systemd scope... Stopped.
/var/lib/kubelet/pods/62773c32-e6f6-11e9-a159-000d3a02729f not found!
Try to stop 'run-r142ec02c0e47457fab402242be706c75.scope' systemd scope... Stopped.
/var/lib/kubelet/pods/041b6526-e6fc-11e9-a159-000d3a02729f not found!
```

_However_ now i'm not sure what happens now when there isn't a pod listed under the scope as this update would NOT remove orphaned cgroups not associated with a pod.

This could be a good or bad thing...