### PR TITLE
Hostpath mount for /var/lib/kubelet/pods

### DIFF
--- a/systemd-cgroup-gc.yaml
+++ b/systemd-cgroup-gc.yaml
@@ -48,7 +48,7 @@ spec:
               memory: 500Ki
             limits:
               cpu: 5m
-              memory: 10Mi  # This crashes on startup with a 5Mi limit, but only uses about 320Ki after that.
+              memory: 50Mi  # This crashes on startup with a 5Mi limit, but only uses about 320Ki after that.
           securityContext:
             privileged: true
           image: ubuntu:16.04
@@ -63,8 +63,14 @@ spec:
           volumeMounts:
             - name: scriptsrc
               mountPath: /usr/local/bin
+            - name: kubeletpath
+              mountPath: /var/lib/kubelet/pods
       volumes:
         - name: scriptsrc
           configMap:
             name: systemd-cgroup-gc
             defaultMode: 0755
+        - name: kubeletpath
+          hostPath:
+                  path: /var/lib/kubelet/pods
+                  type: Directory


### PR DESCRIPTION
* I noticed that this was still breaking some of the pods in our testing cluster.. After reviewing it seems like /var/lib/kubelet/pods/$pod never returned anything because this directory wasn't mounted in the pod. My changes fix this by mounting /var/lib/kubelet/pods using a hostpath volume. After testing I am finally seeing that the pods that are running are not having their cgroups cleaned up and our pods are happy while the cleanup runs. I was not able to test this in AKS as we are using AKS engine.
* Personally I had issues with the 10m limit so I bumped this up to 50m which seemed to be the sweet spot.